### PR TITLE
misc little bug fixes

### DIFF
--- a/Editor/Scripts/IvyEditor.cs
+++ b/Editor/Scripts/IvyEditor.cs
@@ -170,7 +170,7 @@ namespace Hedera
             Ray ray = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
             RaycastHit hit;
 
-            if (Physics.Raycast(ray.origin, ray.direction, out hit, Mathf.Infinity, ivyBehavior.profileAsset.ivyProfile.collisionMask)) 
+            if (Physics.Raycast(ray.origin, ray.direction, out hit, Mathf.Infinity, ivyBehavior.profileAsset.ivyProfile.collisionMask, QueryTriggerInteraction.Ignore)) 
             {
                 mousePos = hit.point + hit.normal * 0.05f;
                 mouseNormal = hit.normal;

--- a/Editor/Scripts/IvyEditor.cs
+++ b/Editor/Scripts/IvyEditor.cs
@@ -272,6 +272,15 @@ namespace Hedera
                 GUI.enabled = false;
             }
 
+            // if Gizmos aren't drawn in scene view, then we can't paint anything since OnSceneGUI() is no longer called... but this warning is only supported in Unity 2019.1 or newer
+            // see issue: https://github.com/radiatoryang/hedera/issues/6
+            #if UNITY_2019_1_OR_NEWER
+            if ( SceneView.drawGizmos == false) {
+                GUI.enabled = false;
+                EditorGUILayout.HelpBox("Gizmos are disabled in the Scene View, which breaks OnSceneGUI(), so ivy painting is disabled.", MessageType.Error);
+            }
+            #endif
+
             // plant root creation button
             var oldColor = GUI.color;
             GUI.color = isPlantingModeActive ? Color.yellow : Color.Lerp(Color.yellow, oldColor, 0.69f);

--- a/Editor/Scripts/IvyEditor.cs
+++ b/Editor/Scripts/IvyEditor.cs
@@ -42,6 +42,10 @@ namespace Hedera
             iconMove = EditorGUIUtility.IconContent("MoveTool").image;
         }
 
+        void OnDisable() {
+            Tools.hidden = false;
+        }
+
         // got working painter code from https://github.com/marmitoTH/Unity-Prefab-Placement-Editor
         private void OnSceneGUI()
         {


### PR DESCRIPTION
- ivy painting now ignores triggers
- trying to fix bug where tool gizmos (move, rotate, scale, etc) can get stuck hidden, if the IvyEditor doesn't have time to re-enable them
- added warning if gizmos are disabled in Unity 2019+ which breaks OnSceneGUI  https://github.com/radiatoryang/hedera/issues/6